### PR TITLE
Added kernel version to syslinux config in installer

### DIFF
--- a/citadel-tool/src/install/installer.rs
+++ b/citadel-tool/src/install/installer.rs
@@ -107,7 +107,7 @@ DEFAULT subgraph
 
 LABEL subgraph
     MENU LABEL Subgraph OS
-    LINUX ../bzImage
+    LINUX ../bzImage-$KERNEL_VERSION
     APPEND root=/dev/mapper/rootfs $KERNEL_CMDLINE
 ";
 


### PR DESCRIPTION
Kernel version wasn't appended to bzImage kernel command-line argument for syslinux, preventing Citadel from booting post-install on Corebooted systems. The fix appends the version.