### PR TITLE
Jan2021 - wayland_socket, remove live mode from citadel-installer-ui, x-terminal-emulator

### DIFF
--- a/citadel-installer-ui/Cargo.toml
+++ b/citadel-installer-ui/Cargo.toml
@@ -3,6 +3,8 @@ name = "citadel-installer-ui"
 version = "0.1.0"
 authors = ["David McKinney <mckinney@subgraph.com>"]
 edition = "2018"
+description = "Citadel Installer UI"
+homepage = "https://subgraph.com"
 
 [dependencies]
 libcitadel = { path = "../libcitadel" }

--- a/citadel-installer-ui/src/main.rs
+++ b/citadel-installer-ui/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
                 gtk::DialogFlags::empty(),
                 gtk::MessageType::Error,
                 gtk::ButtonsType::Cancel,
-                "Citadel Installer can only be run during install or live mode");
+                "Citadel Installer can only be run during install mode");
             dialog.run();
         } else {
             match Ui::build(app) {

--- a/citadel-tool/src/install_backend/mod.rs
+++ b/citadel-tool/src/install_backend/mod.rs
@@ -6,7 +6,7 @@ mod dbus;
 use libcitadel::CommandLine;
 
 pub fn main() {
-    if CommandLine::live_mode() || CommandLine::install_mode() {
+    if CommandLine::install_mode() {
         if let Err(e) = run_dbus_server() {
             warn!("Error: {}", e);
         }

--- a/libcitadel/src/realm/config.rs
+++ b/libcitadel/src/realm/config.rs
@@ -65,6 +65,9 @@ pub struct RealmConfig {
     #[serde(rename="use-wayland")]
     pub use_wayland: Option<bool>,
 
+    #[serde(rename="wayland-socket")]
+    pub wayland_socket: Option<String>,
+ 
     #[serde(rename="use-kvm")]
     pub use_kvm: Option<bool>,
 
@@ -188,6 +191,7 @@ impl RealmConfig {
             use_sound: Some(true),
             use_x11: Some(true),
             use_wayland: Some(true),
+            wayland_socket: Some("wayland-0".to_string()),
             use_kvm: Some(false),
             use_gpu: Some(false),
             use_gpu_card0: Some(false),
@@ -217,6 +221,7 @@ impl RealmConfig {
             use_sound: None,
             use_x11: None,
             use_wayland: None,
+            wayland_socket: None,
             use_kvm: None,
             use_gpu: None,
             use_gpu_card0: None,
@@ -245,8 +250,6 @@ impl RealmConfig {
     pub fn kvm(&self) -> bool {
         self.bool_value(|c| c.use_kvm)
     }
-
-
 
     /// If `true` render node device /dev/dri/renderD128 will be added to realm.
     ///
@@ -317,6 +320,12 @@ impl RealmConfig {
     /// wayland socket /run/user/1000/wayland-0
     pub fn wayland(&self) -> bool {
         self.bool_value(|c| c.use_wayland)
+    }
+
+    /// The name of the wayland socket to use if `self.wayland()` is `true` 
+    /// defaults to wayland-0, will appear in the realm as wayland-0 regardless of value
+    pub fn wayland_socket(&self) -> &str {
+        self.str_value(|c| c.wayland_socket.as_ref()).unwrap_or("wayland-0")
     }
 
     /// If `true` the realm will have access to the network through the zone specified

--- a/libcitadel/src/realm/launcher.rs
+++ b/libcitadel/src/realm/launcher.rs
@@ -140,7 +140,9 @@ impl <'a> RealmLauncher <'a> {
         }
 
         if config.wayland() {
-            writeln!(s, "BindReadOnly=/run/user/1000/wayland-0:/run/user/host/wayland-0")?;
+            // This socket will always be mounted in the realm as wayland-0, regardless of the
+            // value of wayland_socket()
+            writeln!(s, "BindReadOnly=/run/user/1000/{}:/run/user/host/wayland-0", config.wayland_socket())?;
         }
 
         for bind in config.extra_bindmounts() {
@@ -206,7 +208,6 @@ impl <'a> RealmLauncher <'a> {
         for dev in &self.devices {
             writeln!(s, "DeviceAllow={}", dev).unwrap();
         }
-
         REALM_SERVICE_TEMPLATE.replace("$REALM_NAME", self.realm.name())
             .replace("$ROOTFS", &rootfs)
             .replace("$NETNS_ARG", &netns_arg)
@@ -227,3 +228,4 @@ impl From<fmt::Error> for crate::Error {
         format_err!("Error formatting string: {}", e).into()
     }
 }
+

--- a/libcitadel/src/realm/manager.rs
+++ b/libcitadel/src/realm/manager.rs
@@ -91,7 +91,7 @@ impl RealmManager {
     pub fn launch_terminal(&self, realm: &Realm) -> Result<()> {
         info!("opening terminal in realm '{}'", realm.name());
         let title_arg = format!("Realm: {}", realm.name());
-        let args = &["/usr/bin/gnome-terminal".to_owned(), "--title".to_owned(), title_arg];
+        let args = &["/usr/bin/x-terminal-emulator".to_owned(), "--title".to_owned(), title_arg];
         Systemd::machinectl_shell(realm, args, "user", true, true)?;
         Ok(())
     }


### PR DESCRIPTION
- Implement wayland_socket option for realms config (no UI support)
- Removed live mode logic from citadel-installer-ui
- Changed launch_terminal() in realms manager to use 'x-terminal-emulator' path instead of 'gnome-terminal' so that users can configure their own terminal emulator in realms using `update alternatives`