### PR TITLE
Fix realmfs fork bugs

### DIFF
--- a/citadel-realms-ui/src/ui.rs
+++ b/citadel-realms-ui/src/ui.rs
@@ -3,7 +3,6 @@ use gtk::prelude::*;
 use gtk::StyleContext;
 use gdk::ModifierType;
 use gdk::keys::constants;
-use gdk::keys::Key;
 
 use crate::matcher::Matcher;
 use crate::results::ResultList;
@@ -107,7 +106,7 @@ impl Ui {
         if self.result_list.activate_selected(&self.window) {
             println!("activated");
             self.input.set_text("");
-            gtk::idle_add({
+            glib::idle_add_local({
                 let (w,h) = self.window_size;
                 let window = self.window.clone();
                 move || {


### PR DESCRIPTION
Minimal viable patch to so manually the set the name of the forked realmfs and an option to force refreshing stale realmsfs headers.
Also fixed some compile warnings.